### PR TITLE
use try-catch instead of require-component

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,15 @@
 
 /**
- * Wrapper for require to enable simultaneous node/component use.
- */
-
-require = require('require-component')(require);
-
-/**
  * Module dependencies.
  */
 
-var Emitter = require('emitter');
+var Emitter;
+
+try {
+  Emitter = require('component-emitter');
+} catch (err) {
+  Emitter = require('emitter');
+}
 
 /**
  * Expose the event bus.

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "description": "Application-wide event bus",
   "version": "0.1.0",
   "dependencies": {
-    "component-emitter": "*",
-    "require-component": "*"
+    "component-emitter": "*"
   },
   "component": {
     "scripts": {


### PR DESCRIPTION
Rewriting require function by require-component will cause a warning in webpack.

```
Critical dependencies:
6:39-46 require function is used in a way in which dependencies cannot be statically extracted
```
